### PR TITLE
Document Zcash consensus rules in PublicKeyBytes to PublicKey conversion.

### DIFF
--- a/tests/smallorder.rs
+++ b/tests/smallorder.rs
@@ -1,0 +1,15 @@
+use std::convert::TryFrom;
+
+use jubjub::{AffinePoint, Fq};
+
+use redjubjub::*;
+
+#[test]
+fn smallorder_publickey_fails() {
+    // (1,0) is a point of order 4 on any Edwards curve
+    let order4 = AffinePoint::from_raw_unchecked(Fq::one(), Fq::zero());
+    assert_eq!(<bool>::from(order4.is_small_order()), true);
+    let bytes = order4.to_bytes();
+    let pk_bytes = PublicKeyBytes::<SpendAuth>::from(bytes);
+    assert!(PublicKey::<SpendAuth>::try_from(pk_bytes).is_err());
+}


### PR DESCRIPTION
The documentation for the `PublicKey` struct now explains which consensus rules
are checked by the conversion from `PublicKeyBytes`, and small-order public keys are explicitly rejected.