### PR TITLE
Use plain actions-rs for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,22 +3,18 @@ name: CI
 on: [push]
 
 jobs:
-
-  build:
-    name: Google Cloud Build
+  test_nightly:
+    name: test on nightly
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    # - run:
-    - name: Authenticate w/ Google Cloud
-      uses: actions/gcloud/auth@master
-      env:
-        GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}
-    - name: Build, Test, Push to GCR
-      uses: actions/gcloud/cli@master
+    # Because we use nightly features for building docs,
+    # using --all-features will fail without nightly toolchain.
+    - uses: actions-rs/toolchain@v1
       with:
-        entrypoint: bash
-        args: |
-          -l -c "BRANCH_NAME=$GITHUB_REPOSITORY/$(expr $GITHUB_REF : '.*/\(.*\)') && \
-          BRANCH_NAME=${BRANCH_NAME,,} && \
-          gcloud builds submit . --config cloudbuild.yaml --project zealous-zebra --substitutions BRANCH_NAME=$BRANCH_NAME"
+        toolchain: nightly
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all-features


### PR DESCRIPTION
Changed from the GCloud settings because I'm not sure exactly how it works and the more sophisticated setup may not be necessary for this repo.