### PR TITLE
Add Blake2b512 trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ features = ["nightly"]
 [dependencies]
 rand_core = "0.5"
 thiserror = "1.0"
-blake2b_simd = "0.5"
+blake2b_simd = { version = "0.5", optional = true }
 jubjub = "0.3"
 serde = { version = "1", optional = true, features = ["derive"] }
 
@@ -33,4 +33,4 @@ bincode = "1"
 
 [features]
 nightly = []
-default = ["serde"]
+default = ["serde", "blake2b_simd"]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,23 +1,49 @@
-use blake2b_simd::{Params, State};
-
 use crate::Scalar;
 
-/// Provides H^star, the hash-to-scalar function used by RedJubjub.
-pub struct HStar {
-    state: State,
+pub trait Blake2b512 {
+    fn new(personalization: &[u8]) -> Self;
+    fn update(&mut self, data: &[u8]);
+    fn finalize(&self) -> [u8; 64];
 }
 
-impl Default for HStar {
-    fn default() -> Self {
-        let state = Params::new()
+#[cfg(feature = "blake2b_simd")]
+/// Provides Blake2b512 implementation using blake2b_simd
+pub struct StdBlake2b512 {
+    state: blake2b_simd::State,
+}
+
+#[cfg(feature = "blake2b_simd")]
+impl Blake2b512 for StdBlake2b512 {
+    fn new(personalization: &[u8]) -> Self {
+        let state = blake2b_simd::Params::new()
             .hash_length(64)
-            .personal(b"Zcash_RedJubjubH")
+            .personal(personalization)
             .to_state();
+        Self { state }
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.state.update(data);
+    }
+
+    fn finalize(&self) -> [u8; 64] {
+        *self.state.finalize().as_array()
+    }
+}
+
+/// Provides H^star, the hash-to-scalar function used by RedJubjub.
+pub struct HStar<H: Blake2b512> {
+    state: H,
+}
+
+impl<H: Blake2b512> Default for HStar<H> {
+    fn default() -> Self {
+        let state = H::new(b"Zcash_RedJubjubH");
         Self { state }
     }
 }
 
-impl HStar {
+impl<H: Blake2b512> HStar<H> {
     /// Add `data` to the hash, and return `Self` for chaining.
     pub fn update(mut self, data: &[u8]) -> Self {
         self.state.update(data);
@@ -26,6 +52,6 @@ impl HStar {
 
     /// Consume `self` to compute the hash output.
     pub fn finalize(self) -> Scalar {
-        Scalar::from_bytes_wide(self.state.finalize().as_array())
+        Scalar::from_bytes_wide(&self.state.finalize())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,10 @@ pub type Randomizer = jubjub::Fr;
 // XXX-jubjub: upstream this name
 type Scalar = jubjub::Fr;
 
-use hash::HStar;
+use hash::{Blake2b512, HStar};
+
+#[cfg(feature = "blake2b_simd")]
+pub use hash::StdBlake2b512;
 
 pub use error::Error;
 pub use public_key::{PublicKey, PublicKeyBytes};

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -1,6 +1,6 @@
 use std::{convert::TryFrom, marker::PhantomData};
 
-use crate::{Error, Randomizer, Scalar, SigType, Signature, SpendAuth};
+use crate::{Blake2b512, Error, Randomizer, Scalar, SigType, Signature, SpendAuth};
 
 /// A refinement type for `[u8; 32]` indicating that the bytes represent
 /// an encoding of a RedJubJub public key.
@@ -124,7 +124,7 @@ impl<T: SigType> PublicKey<T> {
 
     /// Verify a purported `signature` over `msg` made by this public key.
     // This is similar to impl signature::Verifier but without boxed errors
-    pub fn verify(&self, msg: &[u8], signature: &Signature<T>) -> Result<(), Error> {
+    pub fn verify<H: Blake2b512>(&self, msg: &[u8], signature: &Signature<T>) -> Result<(), Error> {
         #![allow(non_snake_case)]
         use crate::HStar;
 
@@ -149,7 +149,7 @@ impl<T: SigType> PublicKey<T> {
             }
         };
 
-        let c = HStar::default()
+        let c = HStar::<H>::default()
             .update(&signature.r_bytes[..])
             .update(&self.bytes.bytes[..]) // XXX ugly
             .update(msg)

--- a/tests/librustzcash_vectors.rs
+++ b/tests/librustzcash_vectors.rs
@@ -9,7 +9,7 @@ use redjubjub::*;
 fn verify_librustzcash_spendauth() {
     for (msg, sig, pk_bytes) in LIBRUSTZCASH_SPENDAUTH_SIGS.iter() {
         assert!(PublicKey::try_from(*pk_bytes)
-            .and_then(|pk| pk.verify(&msg, &sig))
+            .and_then(|pk| pk.verify::<StdBlake2b512>(&msg, &sig))
             .is_ok());
     }
 }
@@ -18,7 +18,7 @@ fn verify_librustzcash_spendauth() {
 fn verify_librustzcash_binding() {
     for (msg, sig, pk_bytes) in LIBRUSTZCASH_BINDING_SIGS.iter() {
         assert!(PublicKey::try_from(*pk_bytes)
-            .and_then(|pk| pk.verify(&msg, &sig))
+            .and_then(|pk| pk.verify::<StdBlake2b512>(&msg, &sig))
             .is_ok());
     }
 }

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -38,7 +38,7 @@ enum Tweak {
 impl<T: SigType> SignatureCase<T> {
     fn new<R: RngCore + CryptoRng>(mut rng: R, msg: Vec<u8>) -> Self {
         let sk = SecretKey::new(&mut rng);
-        let sig = sk.sign(&mut rng, &msg);
+        let sig = sk.sign::<StdBlake2b512, _>(&mut rng, &msg);
         let pk_bytes = PublicKey::from(&sk).into();
         Self {
             msg,
@@ -64,7 +64,7 @@ impl<T: SigType> SignatureCase<T> {
         // Check that signature validation has the expected result.
         self.is_valid
             == PublicKey::try_from(pk_bytes)
-                .and_then(|pk| pk.verify(&self.msg, &sig))
+                .and_then(|pk| pk.verify::<StdBlake2b512>(&self.msg, &sig))
                 .is_ok()
     }
 


### PR DESCRIPTION
Allow users to provide their own implementation of BLAKE2b-512. Important for hardware wallet support as they have their own, optimized implementations of BLAKE2b-512.

See #24 for detailed rationale and discussion about which the `Blake2b512` trait (and `StdBlake2b512` implementation) should be added to.