### PR TITLE
[Blocked on upstream jubjub publishing to crates.io] Expose upstream's jubjub::Scalar type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ features = ["nightly"]
 rand_core = "0.5"
 thiserror = "1.0"
 blake2b_simd = "0.5"
-jubjub = "0.3"
+jubjub = { git = "https://github.com/zkcrypto/jubjub.git", rev = "af5598d"}
 serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,10 @@ mod public_key;
 mod secret_key;
 mod signature;
 
-/// An element of the JubJub scalar field used for randomization of public and secret keys.
-pub type Randomizer = jubjub::Fr;
+pub use jubjub::Scalar;
 
-/// A better name than Fr.
-// XXX-jubjub: upstream this name
-type Scalar = jubjub::Fr;
+/// An element of the JubJub scalar field used for randomization of public and secret keys.
+pub type Randomizer = jubjub::Scalar;
 
 use hash::HStar;
 


### PR DESCRIPTION
I'm pulling in jubjub just to expose `Scalar` elsewhere, which I would rather not do. I may move that work into here yet, but I'm not sure.