### PR TITLE
Add batch::Item::verify_single and Item: Clone + Debug.

### DIFF
--- a/tests/batch.rs
+++ b/tests/batch.rs
@@ -35,23 +35,65 @@ fn alternating_batch_verify() {
     let rng = thread_rng();
     let mut batch = batch::Verifier::new();
     for i in 0..32 {
-        match i % 2 {
+        let item: batch::Item = match i % 2 {
             0 => {
                 let sk = SigningKey::<SpendAuth>::new(rng);
                 let vk = VerificationKey::from(&sk);
                 let msg = b"BatchVerifyTest";
                 let sig = sk.sign(rng, &msg[..]);
-                batch.queue((vk.into(), sig, msg));
+                (vk.into(), sig, msg).into()
             }
             1 => {
                 let sk = SigningKey::<Binding>::new(rng);
                 let vk = VerificationKey::from(&sk);
                 let msg = b"BatchVerifyTest";
                 let sig = sk.sign(rng, &msg[..]);
-                batch.queue((vk.into(), sig, msg));
+                (vk.into(), sig, msg).into()
             }
-            _ => panic!(),
-        }
+            _ => unreachable!(),
+        };
+        batch.queue(item);
     }
     assert!(batch.verify(rng).is_ok());
+}
+
+#[test]
+fn bad_batch_verify() {
+    let rng = thread_rng();
+    let bad_index = 4; // must be even
+    let mut batch = batch::Verifier::new();
+    let mut items = Vec::new();
+    for i in 0..32 {
+        let item: batch::Item = match i % 2 {
+            0 => {
+                let sk = SigningKey::<SpendAuth>::new(rng);
+                let vk = VerificationKey::from(&sk);
+                let msg = b"BatchVerifyTest";
+                let sig = if i != bad_index {
+                    sk.sign(rng, &msg[..])
+                } else {
+                    sk.sign(rng, b"bad")
+                };
+                (vk.into(), sig, msg).into()
+            }
+            1 => {
+                let sk = SigningKey::<Binding>::new(rng);
+                let vk = VerificationKey::from(&sk);
+                let msg = b"BatchVerifyTest";
+                let sig = sk.sign(rng, &msg[..]);
+                (vk.into(), sig, msg).into()
+            }
+            _ => unreachable!(),
+        };
+        items.push(item.clone());
+        batch.queue(item);
+    }
+    assert!(batch.verify(rng).is_err());
+    for (i, item) in items.drain(..).enumerate() {
+        if i != bad_index {
+            assert!(item.verify_single().is_ok());
+        } else {
+            assert!(item.verify_single().is_err());
+        }
+    }
 }


### PR DESCRIPTION
This closes a gap in the API where it was impossible to retry items in a failed
batch, because the opaque Item type could not be verified individually.

cf https://github.com/ZcashFoundation/ed25519-zebra/pull/27