### PR TITLE
Consistent RedJubjub

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-/// An error related to RedJubJub signatures.
+/// An error related to RedJubjub signatures.
 #[derive(Error, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Error {
     /// The encoding of a signing key was malformed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use signature::Signature;
 pub use signing_key::SigningKey;
 pub use verification_key::{VerificationKey, VerificationKeyBytes};
 
-/// Abstracts over different RedJubJub parameter choices, [`Binding`]
+/// Abstracts over different RedJubjub parameter choices, [`Binding`]
 /// and [`SpendAuth`].
 ///
 /// As described [at the end of §5.4.6][concretereddsa] of the Zcash

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::SigType;
 
-/// A RedJubJub signature.
+/// A RedJubjub signature.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Signature<T: SigType> {

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -7,7 +7,7 @@ use crate::{Error, Randomizer, Scalar, SigType, Signature, SpendAuth, Verificati
 
 use rand_core::{CryptoRng, RngCore};
 
-/// A RedJubJub signing key.
+/// A RedJubjub signing key.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "SerdeHelper"))]

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{Error, Randomizer, Scalar, SigType, Signature, SpendAuth};
 
 /// A refinement type for `[u8; 32]` indicating that the bytes represent
-/// an encoding of a RedJubJub verification key.
+/// an encoding of a RedJubjub verification key.
 ///
 /// This is useful for representing a compressed verification key; the
 /// [`VerificationKey`] type in this library holds other decompressed state
@@ -41,7 +41,7 @@ impl<T: SigType> Hash for VerificationKeyBytes<T> {
     }
 }
 
-/// A valid RedJubJub verification key.
+/// A valid RedJubjub verification key.
 ///
 /// This type holds decompressed state used in signature verification; if the
 /// verification key may not be used immediately, it is probably better to use


### PR DESCRIPTION
According to the [Zcash protocol](https://zips.z.cash/protocol/protocol.pdf), it should be written `RedJubjub`.