### PR TITLE
Migrate to jubjub 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,14 @@ features = ["nightly"]
 blake2b_simd = "0.5"
 byteorder = "1.3"
 digest = "0.9"
-jubjub = "0.3"
+jubjub = "0.6"
 rand_core = "0.5"
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = "1.0"
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
+
+# Temporary workaround for https://github.com/myrrlyn/funty/issues/3
+funty = "=1.1.0"
 
 [dev-dependencies]
 bincode = "1"

--- a/src/frost.rs
+++ b/src/frost.rs
@@ -25,11 +25,12 @@
 
 use std::{collections::HashMap, convert::TryFrom, marker::PhantomData};
 
+use jubjub::Scalar;
 use rand_core::{CryptoRng, RngCore};
 use zeroize::DefaultIsZeroes;
 
 use crate::private::Sealed;
-use crate::{HStar, Scalar, Signature, SpendAuth, VerificationKey};
+use crate::{HStar, Signature, SpendAuth, VerificationKey};
 
 /// A secret scalar value representing a single signer's secret key.
 #[derive(Clone, Copy, Default)]
@@ -648,7 +649,7 @@ pub fn aggregate(
 }
 
 #[cfg(test)]
-    mod tests {
+mod tests {
     use super::*;
     use rand::thread_rng;
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -8,8 +8,8 @@
 // - Deirdre Connolly <deirdre@zfnd.org>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
-use crate::Scalar;
 use blake2b_simd::{Params, State};
+use jubjub::Scalar;
 
 /// Provides H^star, the hash-to-scalar function used by RedJubjub.
 pub struct HStar {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,11 +26,7 @@ mod signing_key;
 mod verification_key;
 
 /// An element of the JubJub scalar field used for randomization of public and secret keys.
-pub type Randomizer = jubjub::Fr;
-
-/// A better name than Fr.
-// XXX-jubjub: upstream this name
-type Scalar = jubjub::Fr;
+pub type Randomizer = jubjub::Scalar;
 
 use hash::HStar;
 

--- a/src/scalar_mul.rs
+++ b/src/scalar_mul.rs
@@ -14,8 +14,6 @@ use std::{borrow::Borrow, fmt::Debug};
 
 use jubjub::*;
 
-use crate::Scalar;
-
 pub trait NonAdjacentForm {
     fn non_adjacent_form(&self, w: usize) -> [i8; 256];
 }

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -13,8 +13,9 @@ use std::{
     marker::PhantomData,
 };
 
-use crate::{Error, Randomizer, Scalar, SigType, Signature, SpendAuth, VerificationKey};
+use crate::{Error, Randomizer, SigType, Signature, SpendAuth, VerificationKey};
 
+use jubjub::Scalar;
 use rand_core::{CryptoRng, RngCore};
 
 /// A RedJubJub signing key.

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -14,7 +14,9 @@ use std::{
     marker::PhantomData,
 };
 
-use crate::{Error, Randomizer, Scalar, SigType, Signature, SpendAuth};
+use jubjub::Scalar;
+
+use crate::{Error, Randomizer, SigType, Signature, SpendAuth};
 
 /// A refinement type for `[u8; 32]` indicating that the bytes represent
 /// an encoding of a RedJubJub verification key.


### PR DESCRIPTION
`jubjub 0.6` depends on `rand_core 0.6` (due to `ff 0.9`), but this doesn't actually affect `redjubjub` since it is manually constructing random scalars via `jubjub::Scalar::from_bytes_wide` instead of using `PrimeField::random`.