### PR TITLE
Avoid null nonces

### DIFF
--- a/src/frost.rs
+++ b/src/frost.rs
@@ -338,13 +338,21 @@ impl SigningNonces {
     where
         R: CryptoRng + RngCore,
     {
-        let mut bytes = [0; 64];
-        rng.fill_bytes(&mut bytes);
-        let hiding = Scalar::from_bytes_wide(&bytes);
+        fn random_nonzero_bytes<R>(rng: &mut R) -> [u8; 64]
+        where
+            R: CryptoRng + RngCore,
+        {
+            let mut bytes = [0; 64];
+            loop {
+                rng.fill_bytes(&mut bytes);
+                if bytes != [0; 64] {
+                    return bytes;
+                }
+            }
+        }
 
-        let mut bytes = [0; 64];
-        rng.fill_bytes(&mut bytes);
-        let binding = Scalar::from_bytes_wide(&bytes);
+        let hiding = Scalar::from_bytes_wide(&random_nonzero_bytes(rng));
+        let binding = Scalar::from_bytes_wide(&random_nonzero_bytes(rng));
 
         Self { hiding, binding }
     }
@@ -462,9 +470,14 @@ fn gen_group_commitment(
     signing_package: &SigningPackage,
     bindings: &HashMap<u32, Scalar>,
 ) -> Result<GroupCommitment, &'static str> {
-    let mut accumulator = jubjub::ExtendedPoint::identity();
+    let identity = jubjub::ExtendedPoint::identity();
+    let mut accumulator = identity;
 
     for commitment in signing_package.signing_commitments.iter() {
+        if identity == commitment.binding && identity == commitment.hiding {
+            return Err("Commitment equals the identity.");
+        }
+
         let rho_i = bindings
             .get(&commitment.index)
             .ok_or("No matching commitment index")?;

--- a/src/frost.rs
+++ b/src/frost.rs
@@ -351,6 +351,8 @@ impl SigningNonces {
             }
         }
 
+        // The values of 'hiding' and 'biding' must be non-zero so that commitments are not the
+        // identity.
         let hiding = Scalar::from_bytes_wide(&random_nonzero_bytes(rng));
         let binding = Scalar::from_bytes_wide(&random_nonzero_bytes(rng));
 
@@ -474,9 +476,11 @@ fn gen_group_commitment(
     let mut accumulator = identity;
 
     for commitment in signing_package.signing_commitments.iter() {
-        if identity == commitment.binding && identity == commitment.hiding {
-            return Err("Commitment equals the identity.");
-        }
+        // The following check prevents a party from accidentally revealing their share.
+        // Note that the '&&' operator would be sufficient.
+            if identity == commitment.binding || identity == commitment.hiding {
+                return Err("Commitment equals the identity.");
+            }
 
         let rho_i = bindings
             .get(&commitment.index)


### PR DESCRIPTION
The values of the variables `binding` and `hiding` are generated so that they are non-zero.

During the group commitment computation, we also check that the commitments are not the identity. This prevents a party from accidentally revealing their share.