### PR TITLE
Derive Debug, PartialEq

### DIFF
--- a/src/frost.rs
+++ b/src/frost.rs
@@ -55,7 +55,7 @@ impl From<Scalar> for Secret {
 }
 
 /// A public group element that represents a single signer's public key.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Public(jubjub::ExtendedPoint);
 
 impl From<jubjub::ExtendedPoint> for Public {


### PR DESCRIPTION
The struct `jubjub::ExtendedPoint` doesn't seem to implement `Eq`, so it can't be derived for `pub struct Public(jubjub::ExtendedPoint);`.