### PR TITLE
Add error type to FROST

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -111,7 +111,7 @@ impl Item {
     /// borrowing the message data, the `Item` type is unlinked from the lifetime of
     /// the message.
     #[allow(non_snake_case)]
-    pub fn verify_single(self) -> Result<(), Error> {
+    pub fn verify_single(self) -> Result<(), SignatureError> {
         match self.inner {
             Inner::Binding { vk_bytes, sig, c } => VerificationKey::<Binding>::try_from(vk_bytes)
                 .and_then(|vk| vk.verify_prehashed(&sig, c)),
@@ -178,7 +178,7 @@ impl Verifier {
     ///
     /// [ps]: https://zips.z.cash/protocol/protocol.pdf#reddsabatchverify
     #[allow(non_snake_case)]
-    pub fn verify<R: RngCore + CryptoRng>(self, mut rng: R) -> Result<(), Error> {
+    pub fn verify<R: RngCore + CryptoRng>(self, mut rng: R) -> Result<(), SignatureError> {
         let n = self.signatures.len();
 
         let mut VK_coeffs = Vec::with_capacity(n);
@@ -200,7 +200,7 @@ impl Verifier {
                 if maybe_scalar.is_some().into() {
                     maybe_scalar.unwrap()
                 } else {
-                    return Err(Error::InvalidSignature);
+                    return Err(SignatureError::Invalid);
                 }
             };
 
@@ -211,7 +211,7 @@ impl Verifier {
                 if maybe_point.is_some().into() {
                     jubjub::ExtendedPoint::from(maybe_point.unwrap())
                 } else {
-                    return Err(Error::InvalidSignature);
+                    return Err(SignatureError::Invalid);
                 }
             };
 
@@ -258,7 +258,7 @@ impl Verifier {
         if check.is_small_order().into() {
             Ok(())
         } else {
-            Err(Error::InvalidSignature)
+            Err(SignatureError::Invalid)
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 
 /// An error related to RedJubJub signatures.
 #[derive(Error, Debug, Copy, Clone, Eq, PartialEq)]
-pub enum Error {
+pub enum SignatureError {
     /// The encoding of a signing key was malformed.
     #[error("Malformed signing key encoding.")]
     MalformedSigningKey,
@@ -21,5 +21,5 @@ pub enum Error {
     MalformedVerificationKey,
     /// Signature verification failed.
     #[error("Invalid signature.")]
-    InvalidSignature,
+    Invalid,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,3 +23,41 @@ pub enum SignatureError {
     #[error("Invalid signature.")]
     Invalid,
 }
+
+/// An error related to FROST functions.
+#[derive(Error, Debug, Copy, Clone, Eq, PartialEq)]
+pub enum FrostError {
+    /// Share verification failed.
+    #[error("Share is invalid.")]
+    InvalidShare,
+    /// The threshold must be greater than 0.
+    #[error("Threshold cannot be 0.")]
+    ZeroThreshold,
+    /// The number of shares must be greater than 0.
+    #[error("Number of shares cannot be 0.")]
+    ZeroShares,
+    /// The threshold must be smaller or equal than the number of shares.
+    #[error("Threshold cannot exceed numshares.")]
+    ThresholdExceedShares,
+    /// Share signature verification.
+    #[error("Invalid signature share")]
+    InvalidSignatureShare,
+    /// The commitment must not be the identity.
+    #[error("Commitment equals the identity.")]
+    IdentiyCommitment,
+    /// The shares provided must not be duplicated.
+    #[error("Duplicate shares provided")]
+    DuplicateShares,
+    /// At least 1 share must be provided.
+    #[error("No shares provided")]
+    NoShares,
+    /// No match in the commitment index.
+    #[error("No matching commitment index")]
+    NoMatchCommitment,
+    /// No match in the binding.
+    #[error("No matching binding")]
+    NoMatchBinding,
+    /// No match in the signing commitment.
+    #[error("No matching signing commitment for signer")]
+    NoMatchSigningCommitment,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub type Randomizer = jubjub::Scalar;
 
 use hash::HStar;
 
-pub use error::Error;
+pub use error::SignatureError;
 pub use signature::Signature;
 pub use signing_key::SigningKey;
 pub use verification_key::{VerificationKey, VerificationKeyBytes};

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -13,7 +13,7 @@ use std::{
     marker::PhantomData,
 };
 
-use crate::{Error, Randomizer, SigType, Signature, SpendAuth, VerificationKey};
+use crate::{error::SignatureError, Randomizer, SigType, Signature, SpendAuth, VerificationKey};
 
 use jubjub::Scalar;
 use rand_core::{CryptoRng, RngCore};
@@ -42,7 +42,7 @@ impl<T: SigType> From<SigningKey<T>> for [u8; 32] {
 }
 
 impl<T: SigType> TryFrom<[u8; 32]> for SigningKey<T> {
-    type Error = Error;
+    type Error = SignatureError;
 
     fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
         // XXX-jubjub: this should not use CtOption
@@ -52,7 +52,7 @@ impl<T: SigType> TryFrom<[u8; 32]> for SigningKey<T> {
             let pk = VerificationKey::from(&sk);
             Ok(SigningKey { sk, pk })
         } else {
-            Err(Error::MalformedSigningKey)
+            Err(SignatureError::MalformedSigningKey)
         }
     }
 }
@@ -61,7 +61,7 @@ impl<T: SigType> TryFrom<[u8; 32]> for SigningKey<T> {
 struct SerdeHelper([u8; 32]);
 
 impl<T: SigType> TryFrom<SerdeHelper> for SigningKey<T> {
-    type Error = Error;
+    type Error = SignatureError;
 
     fn try_from(helper: SerdeHelper) -> Result<Self, Self::Error> {
         helper.0.try_into()


### PR DESCRIPTION
In this PR:

- rename existing `Error` enum into `SignatureError` (https://github.com/ZcashFoundation/redjubjub/commit/5d13f77d390cf5c02241b04ad9faffbfac7eeb41).
- add and use a new error type `FrostError` (https://github.com/ZcashFoundation/redjubjub/commit/2659c58024f0adfd44812824ded43538e821b45a). 

This will close https://github.com/ZcashFoundation/redjubjub/issues/49

I think we can make more in a future PR by adding more code to some of the error types. Also some errors might be not needed (`NoShares` is only used in a test case).