### PR TITLE
Introduce messages and validation to FROST

### DIFF
--- a/src/frost.rs
+++ b/src/frost.rs
@@ -73,7 +73,7 @@ pub struct Share {
 /// This is a (public) commitment to one coefficient of a secret polynomial used
 /// for performing verifiable secret sharing for a Shamir secret share.
 #[derive(Clone)]
-struct Commitment(jubjub::AffinePoint);
+pub struct Commitment(jubjub::AffinePoint);
 
 /// Contains the commitments to the coefficients for our secret polynomial _f_,
 /// used to generate participants' key shares.
@@ -438,7 +438,7 @@ impl SignatureShare {
 /// nonce/commitment pair at a time.  Nonces should be stored in secret storage
 /// for later use, whereas the commitments are published.
 
-/// The number of nonces is limited to 255. This limit can be increased if it 
+/// The number of nonces is limited to 255. This limit can be increased if it
 /// turns out to be too conservative.
 // TODO: Make sure the above is a correct statement, fix if needed in:
 // https://github.com/ZcashFoundation/redjubjub/issues/111

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod constants;
 mod error;
 pub mod frost;
 mod hash;
+mod messages;
 mod scalar_mul;
 mod signature;
 mod signing_key;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,0 +1,140 @@
+//! The FROST communication messages specified in [RFC-001]
+//!
+//! [RFC-001]: https://github.com/ZcashFoundation/redjubjub/blob/main/rfcs/0001-messages.md
+#![allow(dead_code)]
+
+use jubjub::{AffinePoint, Scalar};
+
+use std::collections::HashMap;
+
+mod constants;
+mod validate;
+
+/// The data required to serialize a frost message.
+pub struct Message {
+    header: Header,
+    payload: Payload,
+}
+
+/// The data required to serialize the common header fields for every message.
+///
+/// Note: the `msg_type` is derived from the `payload` enum variant.
+pub struct Header {
+    version: MsgVersion,
+    sender: ParticipantId,
+    receiver: ParticipantId,
+}
+
+/// The data required to serialize the payload for a message.
+pub enum Payload {
+    SharePackage(SharePackage),
+    SigningCommitments(SigningCommitments),
+    SigningPackage(SigningPackage),
+    SignatureShare(SignatureShare),
+    AggregateSignature(AggregateSignature),
+}
+
+/// The numeric values used to identify each `Payload` variant during serialization.
+#[repr(u8)]
+#[non_exhaustive]
+enum MsgType {
+    SharePackage,
+    SigningCommitments,
+    SigningPackage,
+    SignatureShare,
+    AggregateSignature,
+}
+
+/// The numeric values used to identify the protocol version during serialization.
+#[derive(PartialEq)]
+pub struct MsgVersion(u8);
+
+/// The numeric values used to identify each participant during serialization.
+///
+/// In the `frost` module, participant ID `0` should be invalid.
+/// But in serialization, we want participants to be indexed from `0..n`,
+/// where `n` is the number of participants.
+/// This helps us look up their shares and commitments in serialized arrays.
+/// So in serialization, we assign the dealer and aggregator the highest IDs,
+/// and mark those IDs as invalid for signers.
+///
+/// "When performing Shamir secret sharing, a polynomial `f(x)` is used to generate
+/// each party’s share of the secret. The actual secret is `f(0)` and the party with
+/// ID `i` will be given a share with value `f(i)`.
+/// Since a DKG may be implemented in the future, we recommend that the ID `0` be declared invalid."
+/// https://raw.githubusercontent.com/ZcashFoundation/redjubjub/main/zcash-frost-audit-report-20210323.pdf#d
+#[derive(PartialEq, PartialOrd)]
+pub enum ParticipantId {
+    /// A serialized participant ID for a signer.
+    ///
+    /// Must be less than or equal to `MAX_SIGNER_PARTICIPANT_ID`.
+    Signer(u8),
+    /// The fixed participant ID for the dealer.
+    Dealer,
+    /// The fixed participant ID for the aggregator.
+    Aggregator,
+}
+
+/// The data required to serialize `frost::SharePackage`.
+///
+/// The dealer sends this message to each signer for this round.
+/// With this, the signer should be able to build a `SharePackage` and use
+/// the `sign()` function.
+///
+/// Note: `frost::SharePackage.public` can be calculated from `secret_share`.
+pub struct SharePackage {
+    /// This participant's secret key share: `frost::SharePackage.share.value`.
+    secret_share: Scalar,
+    /// Commitment for the signer as a single jubjub::AffinePoint.
+    /// A set of commitments to the coefficients (which themselves are scalars)
+    /// for a secret polynomial _f_: `frost::SharePackage.share.commitment`
+    share_commitment: Vec<AffinePoint>,
+    /// The public signing key that represents the entire group:
+    /// `frost::SharePackage.group_public`.
+    group_public: AffinePoint,
+}
+
+/// The data required to serialize `frost::SigningCommitments`.
+///
+/// Each signer must send this message to the aggregator.
+/// A signing commitment from the first round of the signing protocol.
+pub struct SigningCommitments {
+    /// The hiding point: `frost::SigningCommitments.hiding`
+    hiding: AffinePoint,
+    /// The binding point: `frost::SigningCommitments.binding`
+    binding: AffinePoint,
+}
+
+/// The data required to serialize `frost::SigningPackage`.
+///
+/// The aggregator decides what message is going to be signed and
+/// sends it to each signer with all the commitments collected.
+pub struct SigningPackage {
+    /// The message to be signed: `frost::SigningPackage.message`
+    message: Vec<u8>,
+    /// The collected commitments for each signer as a hashmap of
+    /// unique participant identifiers: `frost::SigningPackage.signing_commitments`
+    ///
+    /// Signing packages that contain duplicate or missing `ParticipantID`s are invalid.
+    signing_commitments: HashMap<ParticipantId, SigningCommitments>,
+}
+
+/// The data required to serialize `frost::SignatureShare`.
+///
+/// Each signer sends their signatures to the aggregator who is going to collect them
+/// and generate a final spend signature.
+pub struct SignatureShare {
+    /// This participant's signature over the message: `frost::SignatureShare.signature`
+    signature: Scalar,
+}
+
+/// The data required to serialize a successful output from `frost::aggregate()`.
+///
+/// The final signature is broadcasted by the aggregator to all signers.
+pub struct AggregateSignature {
+    /// The aggregated group commitment: `Signature<SpendAuth>.r_bytes` returned by `frost::aggregate`
+    group_commitment: AffinePoint,
+    /// A plain Schnorr signature created by summing all the signature shares:
+    /// `Signature<SpendAuth>.s_bytes` returned by `frost::aggregate`
+    schnorr_signature: Scalar,
+}

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -85,15 +85,15 @@ pub enum ParticipantId {
 ///
 /// Note: `frost::SharePackage.public` can be calculated from `secret_share`.
 pub struct SharePackage {
+    /// The public signing key that represents the entire group:
+    /// `frost::SharePackage.group_public`.
+    group_public: VerificationKey<SpendAuth>,
     /// This participant's secret key share: `frost::SharePackage.share.value`.
     secret_share: Scalar,
     /// Commitment for the signer as a single jubjub::AffinePoint.
     /// A set of commitments to the coefficients (which themselves are scalars)
     /// for a secret polynomial _f_: `frost::SharePackage.share.commitment`
     share_commitment: Vec<AffinePoint>,
-    /// The public signing key that represents the entire group:
-    /// `frost::SharePackage.group_public`.
-    group_public: VerificationKey<SpendAuth>,
 }
 
 /// The data required to serialize `frost::SigningCommitments`.
@@ -112,13 +112,15 @@ pub struct SigningCommitments {
 /// The aggregator decides what message is going to be signed and
 /// sends it to each signer with all the commitments collected.
 pub struct SigningPackage {
-    /// The message to be signed: `frost::SigningPackage.message`
-    message: Vec<u8>,
     /// The collected commitments for each signer as a hashmap of
     /// unique participant identifiers: `frost::SigningPackage.signing_commitments`
     ///
     /// Signing packages that contain duplicate or missing `ParticipantID`s are invalid.
     signing_commitments: HashMap<ParticipantId, SigningCommitments>,
+    /// The message to be signed: `frost::SigningPackage.message`.
+    ///
+    /// Each signer should perform protocol-specific verification on the message.
+    message: Vec<u8>,
 }
 
 /// The data required to serialize `frost::SignatureShare`.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -5,6 +5,8 @@
 
 use jubjub::{AffinePoint, Scalar};
 
+use crate::{verification_key::VerificationKey, SpendAuth};
+
 use std::collections::HashMap;
 
 mod constants;
@@ -91,7 +93,7 @@ pub struct SharePackage {
     share_commitment: Vec<AffinePoint>,
     /// The public signing key that represents the entire group:
     /// `frost::SharePackage.group_public`.
-    group_public: AffinePoint,
+    group_public: VerificationKey<SpendAuth>,
 }
 
 /// The data required to serialize `frost::SigningCommitments`.

--- a/src/messages/constants.rs
+++ b/src/messages/constants.rs
@@ -17,6 +17,4 @@ pub const AGGREGATOR_PARTICIPANT_ID: u8 = u8::MAX;
 pub const MAX_SIGNER_PARTICIPANT_ID: u8 = u8::MAX - 2;
 
 /// The maximum length of a Zcash message, in bytes.
-///
-/// This value is used to calculate safe preallocation limits for some types
-pub const MAX_PROTOCOL_MESSAGE_LEN: usize = 2 * 1024 * 1024;
+pub const ZCASH_MAX_PROTOCOL_MESSAGE_LEN: usize = 2 * 1024 * 1024;

--- a/src/messages/constants.rs
+++ b/src/messages/constants.rs
@@ -1,5 +1,8 @@
+//! Definitions of constants.
+
 use super::MsgVersion;
 
+/// The first version of FROST messages
 pub const BASIC_FROST_SERIALIZATION: MsgVersion = MsgVersion(0);
 
 /// The fixed participant ID for the dealer.

--- a/src/messages/constants.rs
+++ b/src/messages/constants.rs
@@ -18,3 +18,9 @@ pub const MAX_SIGNER_PARTICIPANT_ID: u8 = u8::MAX - 2;
 
 /// The maximum length of a Zcash message, in bytes.
 pub const ZCASH_MAX_PROTOCOL_MESSAGE_LEN: usize = 2 * 1024 * 1024;
+
+/// The minimum number of signers of any FROST setup.
+pub const MIN_SIGNERS: usize = 2;
+
+/// The minimum number of signers that must sign.
+pub const MIN_THRESHOLD: usize = 2;

--- a/src/messages/constants.rs
+++ b/src/messages/constants.rs
@@ -16,6 +16,12 @@ pub const AGGREGATOR_PARTICIPANT_ID: u8 = u8::MAX;
 /// We reserve two participant IDs for the dealer and aggregator.
 pub const MAX_SIGNER_PARTICIPANT_ID: u8 = u8::MAX - 2;
 
+/// The maximum number of signers
+///
+/// `MAX_SIGNER_PARTICIPANT_ID` is 253, but the maximum number of signers is actually 254.
+/// (We reserve 2/256 IDs for the dealer and aggregator, leaving 254 valid IDs.)
+pub const MAX_SIGNERS: u8 = MAX_SIGNER_PARTICIPANT_ID + 1;
+
 /// The maximum length of a Zcash message, in bytes.
 pub const ZCASH_MAX_PROTOCOL_MESSAGE_LEN: usize = 2 * 1024 * 1024;
 

--- a/src/messages/constants.rs
+++ b/src/messages/constants.rs
@@ -1,0 +1,19 @@
+use super::MsgVersion;
+
+pub const BASIC_FROST_SERIALIZATION: MsgVersion = MsgVersion(0);
+
+/// The fixed participant ID for the dealer.
+pub const DEALER_PARTICIPANT_ID: u8 = u8::MAX - 1;
+
+/// The fixed participant ID for the aggregator.
+pub const AGGREGATOR_PARTICIPANT_ID: u8 = u8::MAX;
+
+/// The maximum `ParticipantId::Signer` in this serialization format.
+///
+/// We reserve two participant IDs for the dealer and aggregator.
+pub const MAX_SIGNER_PARTICIPANT_ID: u8 = u8::MAX - 2;
+
+/// The maximum length of a Zcash message, in bytes.
+///
+/// This value is used to calculate safe preallocation limits for some types
+pub const MAX_PROTOCOL_MESSAGE_LEN: usize = 2 * 1024 * 1024;

--- a/src/messages/validate.rs
+++ b/src/messages/validate.rs
@@ -3,7 +3,7 @@
 //! [RFC-001#rules]: https://github.com/ZcashFoundation/redjubjub/blob/main/rfcs/0001-messages.md#rules
 
 use super::constants::{
-    BASIC_FROST_SERIALIZATION, MAX_SIGNER_PARTICIPANT_ID, MIN_SIGNERS,
+    BASIC_FROST_SERIALIZATION, MAX_SIGNER_PARTICIPANT_ID, MIN_SIGNERS, MIN_THRESHOLD,
     ZCASH_MAX_PROTOCOL_MESSAGE_LEN,
 };
 use super::*;
@@ -84,7 +84,7 @@ impl Validate for Payload {
         match self {
             Payload::SharePackage(share_package) => {
                 if share_package.share_commitment.len() < MIN_SIGNERS {
-                    return Err(MsgErr::NotEnoughCommitments);
+                    return Err(MsgErr::NotEnoughCommitments(MIN_SIGNERS));
                 }
 
                 if share_package.share_commitment.len() > MAX_SIGNER_PARTICIPANT_ID.into() {
@@ -97,8 +97,8 @@ impl Validate for Payload {
                     return Err(MsgErr::MsgTooBig);
                 }
 
-                if signing_package.signing_commitments.len() < MIN_SIGNERS {
-                    return Err(MsgErr::NotEnoughCommitments);
+                if signing_package.signing_commitments.len() < MIN_THRESHOLD {
+                    return Err(MsgErr::NotEnoughCommitments(MIN_THRESHOLD));
                 }
 
                 if signing_package.signing_commitments.len() > MAX_SIGNER_PARTICIPANT_ID.into() {
@@ -130,8 +130,8 @@ pub enum MsgErr {
     ReceiverMustBeAggergator,
     #[error("the sender of this message must be the aggregator")]
     SenderMustBeAggregator,
-    #[error("the number of signers must be at least {}", MIN_SIGNERS)]
-    NotEnoughCommitments,
+    #[error("the number of signers must be at least {0}")]
+    NotEnoughCommitments(usize),
     #[error(
         "the number of signers can't be more than {}",
         MAX_SIGNER_PARTICIPANT_ID

--- a/src/messages/validate.rs
+++ b/src/messages/validate.rs
@@ -1,0 +1,118 @@
+//! Validation rules specified in [RFC-001#rules]
+//!
+//! [RFC-001#rules]: https://github.com/ZcashFoundation/redjubjub/blob/main/rfcs/0001-messages.md#rules
+
+use super::constants::{
+    BASIC_FROST_SERIALIZATION, MAX_PROTOCOL_MESSAGE_LEN, MAX_SIGNER_PARTICIPANT_ID,
+};
+use super::*;
+
+use thiserror::Error;
+
+pub trait Validate {
+    fn validate(&self) -> Result<&Self, MsgErr>;
+}
+
+impl Validate for Message {
+    fn validate(&self) -> Result<&Self, MsgErr> {
+        match self.payload {
+            Payload::SharePackage(_) => {
+                if self.header.sender != ParticipantId::Dealer {
+                    return Err(MsgErr::SenderMustBeDealer);
+                }
+                if self.header.receiver <= ParticipantId::Signer(MAX_SIGNER_PARTICIPANT_ID) {
+                    return Err(MsgErr::ReceiverMustBeSigner);
+                }
+            }
+            Payload::SigningCommitments(_) => {
+                if self.header.sender <= ParticipantId::Signer(MAX_SIGNER_PARTICIPANT_ID) {
+                    return Err(MsgErr::SenderMustBeSigner);
+                }
+                if self.header.receiver != ParticipantId::Aggregator {
+                    return Err(MsgErr::ReceiverMustBeAggergator);
+                }
+            }
+            Payload::SigningPackage(_) => {
+                if self.header.sender != ParticipantId::Aggregator {
+                    return Err(MsgErr::SenderMustBeAggregator);
+                }
+                if self.header.receiver <= ParticipantId::Signer(MAX_SIGNER_PARTICIPANT_ID) {
+                    return Err(MsgErr::ReceiverMustBeSigner);
+                }
+            }
+            Payload::SignatureShare(_) => {
+                if self.header.sender <= ParticipantId::Signer(MAX_SIGNER_PARTICIPANT_ID) {
+                    return Err(MsgErr::SenderMustBeSigner);
+                }
+                if self.header.receiver != ParticipantId::Aggregator {
+                    return Err(MsgErr::ReceiverMustBeAggergator);
+                }
+            }
+            Payload::AggregateSignature(_) => {
+                if self.header.sender != ParticipantId::Aggregator {
+                    return Err(MsgErr::SenderMustBeAggregator);
+                }
+                if self.header.receiver <= ParticipantId::Signer(MAX_SIGNER_PARTICIPANT_ID) {
+                    return Err(MsgErr::ReceiverMustBeSigner);
+                }
+            }
+        }
+
+        Ok(self)
+    }
+}
+
+impl Validate for Header {
+    fn validate(&self) -> Result<&Self, MsgErr> {
+        // Validate the message version.
+        // By now we only have 1 valid version so we compare against that.
+        if self.version != BASIC_FROST_SERIALIZATION {
+            return Err(MsgErr::WrongVersion);
+        }
+
+        // Make sure the sender and the receiver are not the same.
+        if self.sender == self.receiver {
+            return Err(MsgErr::SameSenderAndReceiver);
+        }
+        Ok(self)
+    }
+}
+
+impl Validate for Payload {
+    fn validate(&self) -> Result<&Self, MsgErr> {
+        match self {
+            Payload::SharePackage(_) => {}
+            Payload::SigningCommitments(_) => {}
+            Payload::SigningPackage(signing_package) => {
+                if signing_package.message.len() > MAX_PROTOCOL_MESSAGE_LEN {
+                    return Err(MsgErr::MsgTooBig);
+                }
+            }
+            Payload::SignatureShare(_) => {}
+            Payload::AggregateSignature(_) => {}
+        }
+
+        Ok(self)
+    }
+}
+
+/// The error a message can produce if it fails validation.
+#[derive(Error, Debug)]
+pub enum MsgErr {
+    #[error("wrong version number")]
+    WrongVersion,
+    #[error("sender and receiver are the same")]
+    SameSenderAndReceiver,
+    #[error("the sender of this message must be the dealer")]
+    SenderMustBeDealer,
+    #[error("the receiver of this message must be a signer")]
+    ReceiverMustBeSigner,
+    #[error("the sender of this message must be a signer")]
+    SenderMustBeSigner,
+    #[error("the receiver of this message must be the aggregator")]
+    ReceiverMustBeAggergator,
+    #[error("the sender of this message must be the aggregator")]
+    SenderMustBeAggregator,
+    #[error("the message is too big")]
+    MsgTooBig,
+}

--- a/src/messages/validate.rs
+++ b/src/messages/validate.rs
@@ -2,9 +2,7 @@
 //!
 //! [RFC-001#rules]: https://github.com/ZcashFoundation/redjubjub/blob/main/rfcs/0001-messages.md#rules
 
-use super::constants::{
-    BASIC_FROST_SERIALIZATION, MAX_PROTOCOL_MESSAGE_LEN, MAX_SIGNER_PARTICIPANT_ID,
-};
+use super::constants::{BASIC_FROST_SERIALIZATION, ZCASH_MAX_PROTOCOL_MESSAGE_LEN};
 use super::*;
 
 use thiserror::Error;
@@ -81,15 +79,15 @@ impl Validate for Header {
 impl Validate for Payload {
     fn validate(&self) -> Result<&Self, MsgErr> {
         match self {
-            Payload::SharePackage(_) => {},
-            Payload::SigningCommitments(_) => {},
+            Payload::SharePackage(_) => {}
+            Payload::SigningCommitments(_) => {}
             Payload::SigningPackage(signing_package) => {
-                if signing_package.message.len() > MAX_PROTOCOL_MESSAGE_LEN {
+                if signing_package.message.len() > ZCASH_MAX_PROTOCOL_MESSAGE_LEN {
                     return Err(MsgErr::MsgTooBig);
                 }
-            },
-            Payload::SignatureShare(_) => {},
-            Payload::AggregateSignature(_) => {},
+            }
+            Payload::SignatureShare(_) => {}
+            Payload::AggregateSignature(_) => {}
         }
 
         Ok(self)

--- a/src/messages/validate.rs
+++ b/src/messages/validate.rs
@@ -81,15 +81,15 @@ impl Validate for Header {
 impl Validate for Payload {
     fn validate(&self) -> Result<&Self, MsgErr> {
         match self {
-            Payload::SharePackage(_) => {}
-            Payload::SigningCommitments(_) => {}
+            Payload::SharePackage(_) => {},
+            Payload::SigningCommitments(_) => {},
             Payload::SigningPackage(signing_package) => {
                 if signing_package.message.len() > MAX_PROTOCOL_MESSAGE_LEN {
                     return Err(MsgErr::MsgTooBig);
                 }
-            }
-            Payload::SignatureShare(_) => {}
-            Payload::AggregateSignature(_) => {}
+            },
+            Payload::SignatureShare(_) => {},
+            Payload::AggregateSignature(_) => {},
         }
 
         Ok(self)

--- a/src/messages/validate.rs
+++ b/src/messages/validate.rs
@@ -3,7 +3,7 @@
 //! [RFC-001#rules]: https://github.com/ZcashFoundation/redjubjub/blob/main/rfcs/0001-messages.md#rules
 
 use super::constants::{
-    BASIC_FROST_SERIALIZATION, MAX_SIGNER_PARTICIPANT_ID, MIN_SIGNERS, MIN_THRESHOLD,
+    BASIC_FROST_SERIALIZATION, MAX_SIGNERS, MIN_SIGNERS, MIN_THRESHOLD,
     ZCASH_MAX_PROTOCOL_MESSAGE_LEN,
 };
 use super::*;
@@ -87,7 +87,7 @@ impl Validate for Payload {
                     return Err(MsgErr::NotEnoughCommitments(MIN_SIGNERS));
                 }
 
-                if share_package.share_commitment.len() > MAX_SIGNER_PARTICIPANT_ID.into() {
+                if share_package.share_commitment.len() > MAX_SIGNERS.into() {
                     return Err(MsgErr::TooManyCommitments);
                 }
             }
@@ -101,7 +101,7 @@ impl Validate for Payload {
                     return Err(MsgErr::NotEnoughCommitments(MIN_THRESHOLD));
                 }
 
-                if signing_package.signing_commitments.len() > MAX_SIGNER_PARTICIPANT_ID.into() {
+                if signing_package.signing_commitments.len() > MAX_SIGNERS.into() {
                     return Err(MsgErr::TooManyCommitments);
                 }
             }
@@ -132,10 +132,7 @@ pub enum MsgErr {
     SenderMustBeAggregator,
     #[error("the number of signers must be at least {0}")]
     NotEnoughCommitments(usize),
-    #[error(
-        "the number of signers can't be more than {}",
-        MAX_SIGNER_PARTICIPANT_ID
-    )]
+    #[error("the number of signers can't be more than {}", MAX_SIGNERS)]
     TooManyCommitments,
     #[error(
         "the message field can't be bigger than {}",

--- a/src/messages/validate.rs
+++ b/src/messages/validate.rs
@@ -2,7 +2,9 @@
 //!
 //! [RFC-001#rules]: https://github.com/ZcashFoundation/redjubjub/blob/main/rfcs/0001-messages.md#rules
 
-use super::constants::{BASIC_FROST_SERIALIZATION, ZCASH_MAX_PROTOCOL_MESSAGE_LEN};
+use super::constants::{
+    BASIC_FROST_SERIALIZATION, MAX_SIGNER_PARTICIPANT_ID, ZCASH_MAX_PROTOCOL_MESSAGE_LEN,
+};
 use super::*;
 
 use thiserror::Error;
@@ -79,7 +81,11 @@ impl Validate for Header {
 impl Validate for Payload {
     fn validate(&self) -> Result<&Self, MsgErr> {
         match self {
-            Payload::SharePackage(_) => {}
+            Payload::SharePackage(share_package) => {
+                if share_package.share_commitment.len() > MAX_SIGNER_PARTICIPANT_ID.into() {
+                    return Err(MsgErr::ShareCommitmentTooBig);
+                }
+            }
             Payload::SigningCommitments(_) => {}
             Payload::SigningPackage(signing_package) => {
                 if signing_package.message.len() > ZCASH_MAX_PROTOCOL_MESSAGE_LEN {
@@ -111,6 +117,8 @@ pub enum MsgErr {
     ReceiverMustBeAggergator,
     #[error("the sender of this message must be the aggregator")]
     SenderMustBeAggregator,
-    #[error("the message is too big")]
+    #[error("the share_commitment field is too big")]
+    ShareCommitmentTooBig,
+    #[error("the message field is too big")]
     MsgTooBig,
 }

--- a/src/messages/validate.rs
+++ b/src/messages/validate.rs
@@ -20,12 +20,12 @@ impl Validate for Message {
                 if self.header.sender != ParticipantId::Dealer {
                     return Err(MsgErr::SenderMustBeDealer);
                 }
-                if self.header.receiver <= ParticipantId::Signer(MAX_SIGNER_PARTICIPANT_ID) {
+                if !matches!(self.header.receiver, ParticipantId::Signer(_)) {
                     return Err(MsgErr::ReceiverMustBeSigner);
                 }
             }
             Payload::SigningCommitments(_) => {
-                if self.header.sender <= ParticipantId::Signer(MAX_SIGNER_PARTICIPANT_ID) {
+                if !matches!(self.header.sender, ParticipantId::Signer(_)) {
                     return Err(MsgErr::SenderMustBeSigner);
                 }
                 if self.header.receiver != ParticipantId::Aggregator {
@@ -36,12 +36,12 @@ impl Validate for Message {
                 if self.header.sender != ParticipantId::Aggregator {
                     return Err(MsgErr::SenderMustBeAggregator);
                 }
-                if self.header.receiver <= ParticipantId::Signer(MAX_SIGNER_PARTICIPANT_ID) {
+                if !matches!(self.header.receiver, ParticipantId::Signer(_)) {
                     return Err(MsgErr::ReceiverMustBeSigner);
                 }
             }
             Payload::SignatureShare(_) => {
-                if self.header.sender <= ParticipantId::Signer(MAX_SIGNER_PARTICIPANT_ID) {
+                if !matches!(self.header.sender, ParticipantId::Signer(_)) {
                     return Err(MsgErr::SenderMustBeSigner);
                 }
                 if self.header.receiver != ParticipantId::Aggregator {
@@ -52,7 +52,7 @@ impl Validate for Message {
                 if self.header.sender != ParticipantId::Aggregator {
                     return Err(MsgErr::SenderMustBeAggregator);
                 }
-                if self.header.receiver <= ParticipantId::Signer(MAX_SIGNER_PARTICIPANT_ID) {
+                if !matches!(self.header.receiver, ParticipantId::Signer(_)) {
                     return Err(MsgErr::ReceiverMustBeSigner);
                 }
             }


### PR DESCRIPTION
Based on the design we are working on https://github.com/ZcashFoundation/redjubjub/pull/85 i am submitting some initial implementation so we can catch some early issues.

This PR attempts to define the new structures, constants and validation:

- [x] Add all the message structures to a `messages.rs` module.
- [x] Add all constants to a `messages/constants.rs` module.
- [x] Add all the validation to a `messages/validate.rs` module.

For the validation we need to cover all the rules from the spec:

#### Header

- [x] ~~`msg_type` must be a known `MsgType` value.~~ (enforced by deserialization)
- [x] `version` must be a supported version.
- [x] `sender` and `receiver` can't be the same.
- [x] ~~If `sender` and `receiver` are a `ParticipantId::Signer`, they must be less than the number of participants in this round.~~ (out of scope: requires validation state)
- [x] The `ParticipantId` variants of `sender` and `receiver` must match the message type.

#### Payloads

- [x] `share_commitments`: length must be less than or equal to `MAX_SIGNER_PARTICIPANT_ID`.
- [x] `signing_commitments`:
    - [x] Length must be less than or equal to `MAX_SIGNER_PARTICIPANT_ID`.
    - [x] Lenght must be at least `MIN_SIGNERS`.
    - [x] <strike>Signing packages that contain duplicate `ParticipantId`s are invalid</strike> We don't need to implement as it is implicit in the use of `HashMap`
    - [x] <strike>Signing packages that contain missing `ParticipantId`s are invalid
        - Note: missing participants are supported by the serialization format.
          But implementations can require full participation in each round.</strike> 
       We can't know in this stage if we have missing signers, we can just make sure that they are at least `MIN_THRESHOLD`
- [x] `message`: signed messages have a protocol-specific length limit.
  For Zcash, that limit is the maximum network protocol message length: `2^21` bytes (2 MB).