### PR TITLE
Fix audit 3.6: Typo in a comment

### DIFF
--- a/src/frost.rs
+++ b/src/frost.rs
@@ -516,7 +516,7 @@ fn gen_challenge(
         .finalize()
 }
 
-/// Generates the langrange coefficient for the i'th participant.
+/// Generates the lagrange coefficient for the i'th participant.
 fn gen_lagrange_coeff(
     signer_index: u8,
     signing_package: &SigningPackage,


### PR DESCRIPTION
https://github.com/ZcashFoundation/redjubjub/blob/main/zcash-frost-audit-report-20210323.pdf

`3.6 Typo in a comment` pag. 9