### PR TITLE
Fix Unused values

### DIFF
--- a/src/frost.rs
+++ b/src/frost.rs
@@ -140,6 +140,7 @@ impl TryFrom<SharePackage> for KeyPackage {
 /// When using a central dealer, [`SharePackage`]s are distributed to
 /// participants, who then perform verification, before deriving
 /// [`KeyPackage`]s, which they store to later use during signing.
+#[allow(dead_code)]
 pub struct KeyPackage {
     index: u8,
     secret_share: Secret,


### PR DESCRIPTION
There are a few warnings when building of a struct not being used. This is also an action point from the audit.

I think the `KeyPackage` struct is going to be used and that we should keep it but in the short run it is probably going to be used only in test cases (Use of a structure inside test code will not pass the lint).

So, by now i think the best will be to allow the dead code.