### PR TITLE
Upgrade byteorder to 1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ features = ["nightly"]
 
 [dependencies]
 blake2b_simd = "0.5"
-byteorder = "1.3"
+byteorder = "1.4"
 digest = "0.9"
 jubjub = "0.6"
 rand_core = "0.6"


### PR DESCRIPTION
From the audit "3.2 Outdated dependencies"

The `rand_core` was updated on April 3rd. This PR updates `byteorder`.

We should check how we are in all other dependencies, best if we can automate it.