### PR TITLE
Change participant identifiers in Trusted Dealer variant

### DIFF
--- a/src/frost.rs
+++ b/src/frost.rs
@@ -443,7 +443,11 @@ impl SignatureShare {
 /// perform the first round. Batching entails generating more than one
 /// nonce/commitment pair at a time.  Nonces should be stored in secret storage
 /// for later use, whereas the commitments are published.
+<<<<<<< HEAD
 
+=======
+///
+>>>>>>> 316082b (Change the type of the identifiers from u8 to u64)
 /// The number of nonces is limited to 255. This limit can be increased if it
 /// turns out to be too conservative.
 // TODO: Make sure the above is a correct statement, fix if needed in:

--- a/src/frost.rs
+++ b/src/frost.rs
@@ -247,11 +247,11 @@ fn generate_id(secret: &Secret, index: u8) -> u64 {
     hasher
         .update("FROST_id".as_bytes())
         .update(jubjub::AffinePoint::from(SpendAuth::basepoint() * secret.0).to_bytes())
-        .update(index.to_be_bytes());
+        .update(index.to_le_bytes());
 
     let id_bytes = hasher.finalize().to_bytes();
 
-    u64::from_be_bytes(id_bytes[0..8].try_into().expect("slice of incorrect size"))
+    u64::from_le_bytes(id_bytes[0..8].try_into().expect("slice of incorrect size"))
 }
 /// Creates secret shares for a given secret.
 ///

--- a/src/frost.rs
+++ b/src/frost.rs
@@ -467,11 +467,7 @@ impl SignatureShare {
 /// perform the first round. Batching entails generating more than one
 /// nonce/commitment pair at a time.  Nonces should be stored in secret storage
 /// for later use, whereas the commitments are published.
-<<<<<<< HEAD
-
-=======
 ///
->>>>>>> 316082b (Change the type of the identifiers from u8 to u64)
 /// The number of nonces is limited to 255. This limit can be increased if it
 /// turns out to be too conservative.
 // TODO: Make sure the above is a correct statement, fix if needed in:

--- a/src/messages/tests/integration.rs
+++ b/src/messages/tests/integration.rs
@@ -69,8 +69,8 @@ fn validate_sharepackage() {
 
     let payload = Payload::SharePackage(SharePackage {
         group_public,
-        secret_share: secret_share,
-        share_commitment: share_commitment,
+        secret_share,
+        share_commitment,
     });
     let validate_payload = Validate::validate(&payload);
     let valid_payload = validate_payload.expect("a valid payload").clone();
@@ -101,7 +101,7 @@ fn validate_sharepackage() {
     // change the payload to have only 1 commitment
     let payload = Payload::SharePackage(SharePackage {
         group_public,
-        secret_share: secret_share,
+        secret_share,
         share_commitment: share_commitment.clone(),
     });
     let validate_payload = Validate::validate(&payload);
@@ -151,7 +151,7 @@ fn serialize_sharepackage() {
     });
 
     let message = Message {
-        header: header,
+        header,
         payload: payload.clone(),
     };
 
@@ -246,7 +246,7 @@ fn serialize_signingcommitments() {
     let payload = Payload::SigningCommitments(SigningCommitments { hiding, binding });
 
     let message = Message {
-        header: header,
+        header,
         payload: payload.clone(),
     };
 
@@ -341,7 +341,7 @@ fn validate_signingpackage() {
     let header = create_valid_header(setup.aggregator, setup.dealer);
 
     let message = Message {
-        header: header,
+        header,
         payload: payload.clone(),
     };
 
@@ -377,7 +377,7 @@ fn serialize_signingpackage() {
     });
 
     let message = Message {
-        header: header,
+        header,
         payload: payload.clone(),
     };
 
@@ -472,7 +472,7 @@ fn serialize_signatureshare() {
     let payload = Payload::SignatureShare(SignatureShare { signature });
 
     let message = Message {
-        header: header,
+        header,
         payload: payload.clone(),
     };
 
@@ -622,8 +622,8 @@ fn btreemap() {
 fn create_valid_header(sender: ParticipantId, receiver: ParticipantId) -> Header {
     Validate::validate(&Header {
         version: constants::BASIC_FROST_SERIALIZATION,
-        sender: sender,
-        receiver: receiver,
+        sender,
+        receiver,
     })
     .expect("always a valid header")
     .clone()
@@ -697,8 +697,8 @@ fn full_setup() -> (Setup, signature::Signature<SpendAuth>) {
     let (shares, pubkeys) =
         frost::keygen_with_dealer(setup.num_signers, setup.threshold, setup.rng.clone()).unwrap();
 
-    let mut nonces: std::collections::HashMap<u64, Vec<frost::SigningNonces>> =
-        std::collections::HashMap::with_capacity(setup.threshold as usize);
+    let mut nonces: HashMap<u64, Vec<frost::SigningNonces>> =
+        HashMap::with_capacity(setup.threshold as usize);
     let mut commitments: Vec<frost::SigningCommitments> =
         Vec::with_capacity(setup.threshold as usize);
 
@@ -714,7 +714,9 @@ fn full_setup() -> (Setup, signature::Signature<SpendAuth>) {
     // aggregator generates a signing package
     let mut signature_shares: Vec<frost::SignatureShare> =
         Vec::with_capacity(setup.threshold as usize);
+
     let message = "message to sign".as_bytes().to_vec();
+
     let signing_package = frost::SigningPackage {
         message: message.clone(),
         signing_commitments: commitments,

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -15,11 +15,12 @@ fn check_sign_with_dealer() {
     let mut commitments: Vec<frost::SigningCommitments> = Vec::with_capacity(threshold as usize);
 
     // Round 1, generating nonces and signing commitments for each participant.
-    for participant_index in 1..(threshold + 1) {
+    // Participants are represented by shares.
+    for share in &shares {
         // Generate one (1) nonce and one SigningCommitments instance for each
         // participant, up to _threshold_.
-        let (nonce, commitment) = frost::preprocess(1, participant_index as u64, &mut rng);
-        nonces.insert(participant_index as u64, nonce);
+        let (nonce, commitment) = frost::preprocess(1, share.index, &mut rng);
+        nonces.insert(share.index, nonce);
         commitments.push(commitment[0]);
     }
 

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -15,7 +15,7 @@ fn check_sign_with_dealer() {
     let mut commitments: Vec<frost::SigningCommitments> = Vec::with_capacity(threshold as usize);
 
     // Round 1, generating nonces and signing commitments for each participant.
-    // Participants are represented by shares.
+    // Shares represent participants.
     for share in &shares {
         // Generate one (1) nonce and one SigningCommitments instance for each
         // participant, up to _threshold_.


### PR DESCRIPTION
At the moment, the identifiers are changed from u8 to u64.

This will close issue #77 once the identifiers are generated by the hash function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/redjubjub/108)
<!-- Reviewable:end -->
