### PR TITLE
Remove indices

### DIFF
--- a/src/frost.rs
+++ b/src/frost.rs
@@ -443,7 +443,11 @@ impl SignatureShare {
 /// perform the first round. Batching entails generating more than one
 /// nonce/commitment pair at a time.  Nonces should be stored in secret storage
 /// for later use, whereas the commitments are published.
+<<<<<<< HEAD
 
+=======
+///
+>>>>>>> 316082b (Change the type of the identifiers from u8 to u64)
 /// The number of nonces is limited to 255. This limit can be increased if it
 /// turns out to be too conservative.
 // TODO: Make sure the above is a correct statement, fix if needed in:

--- a/src/frost.rs
+++ b/src/frost.rs
@@ -247,11 +247,11 @@ fn generate_id(secret: &Secret, index: u8) -> u64 {
     hasher
         .update("FROST_id".as_bytes())
         .update(jubjub::AffinePoint::from(SpendAuth::basepoint() * secret.0).to_bytes())
-        .update(index.to_be_bytes());
+        .update(index.to_le_bytes());
 
     let id_bytes = hasher.finalize().to_bytes();
 
-    u64::from_be_bytes(id_bytes[0..8].try_into().expect("slice of incorrect size"))
+    u64::from_le_bytes(id_bytes[0..8].try_into().expect("slice of incorrect size"))
 }
 /// Creates secret shares for a given secret.
 ///

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -19,8 +19,8 @@ fn check_sign_with_dealer() {
     for share in &shares {
         // Generate one (1) nonce and one SigningCommitments instance for each
         // participant, up to _threshold_.
-        let (nonce, commitment) = frost::preprocess(1, share.index, &mut rng);
-        nonces.insert(share.index, nonce);
+        let (nonce, commitment) = frost::preprocess(1, share.id, &mut rng);
+        nonces.insert(share.id, nonce);
         commitments.push(commitment[0]);
     }
 
@@ -35,10 +35,10 @@ fn check_sign_with_dealer() {
     };
 
     // Round 2: each participant generates their signature share
-    for (participant_index, nonce) in nonces {
+    for (participant_id, nonce) in nonces {
         let share_package = shares
             .iter()
-            .find(|share| participant_index == share.index)
+            .find(|share| participant_id == share.id)
             .unwrap();
         let nonce_to_use = nonce[0];
         // Each participant generates their signature share.

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -15,11 +15,12 @@ fn check_sign_with_dealer() {
     let mut commitments: Vec<frost::SigningCommitments> = Vec::with_capacity(threshold as usize);
 
     // Round 1, generating nonces and signing commitments for each participant.
-    for participant_index in 1..(threshold + 1) {
+    // Participants are represented by shares.
+    for share in &shares {
         // Generate one (1) nonce and one SigningCommitments instance for each
         // participant, up to _threshold_.
-        let (nonce, commitment) = frost::preprocess(1, participant_index as u64, &mut rng);
-        nonces.insert(participant_index as u64, nonce);
+        let (nonce, commitment) = frost::preprocess(1, share.index, &mut rng);
+        nonces.insert(share.index, nonce);
         commitments.push(commitment[0]);
     }
 


### PR DESCRIPTION
The previous implementation was using an `index` to refer to a particular FROST
participant. These references are handled in a different manner now, so they
were changed to `id`s (identifiers).

Resolves #116 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/redjubjub/121)
<!-- Reviewable:end -->
