### PR TITLE
Make the messages module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod constants;
 mod error;
 pub mod frost;
 mod hash;
-mod messages;
+pub mod messages;
 mod scalar_mul;
 pub(crate) mod signature;
 mod signing_key;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -104,10 +104,15 @@ pub struct Header {
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub enum Payload {
+    /// The data required to serialize [`frost::SharePackage`].
     SharePackage(SharePackage),
+    /// The data required to serialize [`frost::SigningCommitments`].
     SigningCommitments(SigningCommitments),
+    /// The data required to serialize [`frost::SigningPackage`].
     SigningPackage(SigningPackage),
+    /// The data required to serialize [`frost::SignatureShare`].
     SignatureShare(SignatureShare),
+    /// The data required to serialize a successful output from [`frost::aggregate()`].
     AggregateSignature(AggregateSignature),
 }
 


### PR DESCRIPTION
This PR changes the visibility of the `messages` mod to pub so that it's available from the outside of the RedJubjub crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/redjubjub/128)
<!-- Reviewable:end -->
