### PR TITLE
Upgrade jubjub to 0.9, blake2b_simd to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 Entries are listed in reverse chronological order.
 
-## Unreleased
+## 0.5.0
 
+* Upgrade `jubjub` to 0.9, `blake2b_simd` to 1
 * Fixed a bug where small-order verification keys (including the identity) were
   handled inconsistently: the `VerificationKey` parsing logic rejected them, but
   the identity `VerificationKey` could be produced from the zero `SigningKey`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,9 @@
 name = "redjubjub"
 edition = "2018"
 # When releasing to crates.io:
-# - Update html_root_url
 # - Update CHANGELOG.md
 # - Create git tag.
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Henry de Valence <hdevalence@hdevalence.ca>", "Deirdre Connolly <durumcrustulum@gmail.com>", "Chelsea Komlo <me@chelseakomlo.com>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
@@ -18,10 +17,10 @@ description = "A standalone implementation of the RedJubjub signature scheme."
 features = ["nightly"]
 
 [dependencies]
-blake2b_simd = "0.5"
+blake2b_simd = "1"
 byteorder = "1.4"
 digest = "0.9"
-jubjub = "0.8"
+jubjub = "0.9"
 rand_core = "0.6"
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = "1.0"


### PR DESCRIPTION
For the Zebra 1.0.0-beta.10 release which needs to matches the crates versions froms zcashd 5.0.0, we need to upgrade jubjub so that we upgrade ff, etc.

I haven't upgraded `digest` because there seem to be a bunch of other crates still depending on it (e.g. `curve25519-dalek`) but we could update anyway since some other crates already did (`ripemd`)