### PR TITLE
remove unneeded digest dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Entries are listed in reverse chronological order.
 
+## 0.5.1
+
+* Remove unneeded `digest` dependency
+
 ## 0.5.0
 
 * Upgrade `jubjub` to 0.9, `blake2b_simd` to 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ features = ["nightly"]
 [dependencies]
 blake2b_simd = "1"
 byteorder = "1.4"
-digest = "0.9"
 jubjub = "0.9"
 rand_core = "0.6"
 serde = { version = "1", optional = true, features = ["derive"] }


### PR DESCRIPTION
This was done in `reddsa` but we forgot to do it here too.

Closes https://github.com/ZcashFoundation/redjubjub/issues/154