### PR TITLE
Remove dependabot for cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,3 @@ updates:
   - conradoplg
   assignees:
   - conradoplg
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-    timezone: America/New_York
-  open-pull-requests-limit: 10
-  reviewers:
-  - conradoplg
-  assignees:
-  - conradoplg


### PR DESCRIPTION
It generates too much noise and we can validate and update dependencies everytime we make a release